### PR TITLE
xpcconnectiontoken is hashable

### DIFF
--- a/Sources/SecureXPC/Server/XPCConnectionToken.swift
+++ b/Sources/SecureXPC/Server/XPCConnectionToken.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-public struct XPCConnectionToken {
+public struct XPCConnectionToken: Hashable {
 
     public let id: UUID
     public let clientPID: pid_t


### PR DESCRIPTION
XPCConnectionToken is hashable
So it can be used:
* as Dictionary keys
* as a single entity to identify a connection