### PR TITLE
Add XPCMachServer invalidation logic

### DIFF
--- a/Sources/SecureXPC/Server/XPCMachServer.swift
+++ b/Sources/SecureXPC/Server/XPCMachServer.swift
@@ -43,7 +43,13 @@ internal class XPCMachServer: XPCServer {
         })
         xpc_connection_resume(self.listenerConnection)
     }
-    
+
+	internal override func invalidate() {
+		self.listenerQueue.sync {
+			xpc_connection_cancel(self.listenerConnection)
+		}
+	}
+
     public override func startAndBlock() -> Never {
         self.start()
 
@@ -118,4 +124,20 @@ extension XPCMachServer {
             return server
         }
     }
+
+	/// Finds a cached server by its Mach service name, invalidates it and removes it from cache.
+	///
+	/// This provides a thread-safe way to shut down a specific, shared server instance
+	/// from anywhere in the application. If no server with the given name is found
+	/// in the cache, this method does nothing.
+	///
+	/// - Parameter machServiceName: The name of the Mach service server to invalidate.
+	internal static func invalidateServer(named machServiceName: String) {
+		serialQueue.sync {
+			if let cachedServer = machServerCache[machServiceName] {
+				machServerCache[machServiceName] = nil
+				cachedServer.invalidate()
+			}
+		}
+	}
 }

--- a/Sources/SecureXPC/Server/XPCMachServer.swift
+++ b/Sources/SecureXPC/Server/XPCMachServer.swift
@@ -11,16 +11,40 @@ import Foundation
 ///
 /// In the case of this framework, the XPC Mach service is expected to be communicated with by an `XPCMachClient`.
 internal class XPCMachServer: XPCServer {
+
+	// MARK: Nested
+
+	/// Defines the lifecycle states of the XPCMachServer.
+	private enum State {
+		/// The server has been initialized but not yet started.
+		/// Connections received in this state are held pending the call to `start()`.
+		case pending(connections: [xpc_connection_t])
+		/// The server is started and actively processing incoming connections.
+		case started
+		/// The server is shutting down and is waiting for the system to confirm the listener connection has been invalidated.
+		case invalidating(queue: DispatchQueue, completion: () -> Void)
+		/// The server has been fully invalidated.
+		case invalidated
+
+		///
+		var isInvalidating: Bool {
+			if case .invalidating = self {
+				return true
+			}
+			return false
+		}
+	}
+
+	// MARK: Properties
+
     /// Name of the service.
     private let machServiceName: String
     /// Receives new incoming connections
     private let listenerConnection: xpc_connection_t
     /// The dispatch queue used when new connections are being received
     private let listenerQueue: DispatchQueue
-    /// Whether this server has been started, if not connections are added to pendingConnections
-    private var started = false
-    /// Connections received while the server is not started
-    private var pendingConnections = [xpc_connection_t]()
+	/// The current lifecycle state of the server.
+	private var state: State = .pending(connections: [])
     
     /// This should only ever be called from `getXPCMachServer(...)` so that client requirement invariants are upheld.
     private init(criteria: MachServiceCriteria) {
@@ -34,19 +58,57 @@ internal class XPCMachServer: XPCServer {
         super.init(clientRequirement: criteria.clientRequirement)
         
         // Configure listener for new connections, all received events are incoming client connections
-        xpc_connection_set_event_handler(self.listenerConnection, { connection in
-            if self.started {
-                self.startClientConnection(connection)
-            } else {
-                self.pendingConnections.append(connection)
-            }
+        xpc_connection_set_event_handler(self.listenerConnection, { event in
+			self.listenerQueue.async {
+				if xpc_get_type(event) == XPC_TYPE_CONNECTION {
+					let clientConnection = event as xpc_connection_t
+					switch self.state {
+					case .pending(let connections):
+						self.state = .pending(connections: connections + [clientConnection])
+					case .started:
+						self.startClientConnection(clientConnection)
+					default:
+						// Cancels any new connections that might arrive during invalidation
+						xpc_connection_cancel(clientConnection)
+					}
+				} else if xpc_get_type(event) == XPC_TYPE_ERROR {
+					// The only EXPECTED error is `XPC_ERROR_CONNECTION_INVALID` when we are already invalidating.
+					if !(self.state.isInvalidating && xpc_equal(event, XPC_ERROR_CONNECTION_INVALID)) {
+						let xpcError = XPCError.fromXPCObject(event)
+						self.errorHandler.handle(xpcError, nil)
+					}
+
+					if case let .invalidating(queue, completion) = self.state {
+						self.state = .invalidated
+						queue.async { completion() }
+					} else {
+						// In all error cases, the listener is now dead. Move to the final state.
+						self.state = .invalidated
+					}
+				}
+			}
         })
         xpc_connection_resume(self.listenerConnection)
     }
 
-	internal override func invalidate() {
+	internal override func invalidate(
+		on queue: DispatchQueue,
+		completion: @escaping () -> Void
+	) {
 		self.listenerQueue.sync {
-			xpc_connection_cancel(self.listenerConnection)
+			// Only proceed if the server is in a state that can be invalidated
+			switch self.state {
+			case .pending, .started:
+				// The final transition to `.invalidated` will happen in the event handler
+				self.state = .invalidating(queue: queue, completion: completion)
+				xpc_connection_cancel(self.listenerConnection)
+			case .invalidated:
+				// If already invalidated, complete immediately.
+				queue.async { completion() }
+			case .invalidating:
+				// An invalidation is already in progress, ignore this new request.
+				break
+			}
 		}
 	}
 
@@ -68,13 +130,18 @@ internal class XPCMachServer: XPCServer {
 }
 
 extension XPCMachServer: XPCNonBlockingServer {
+	/// Transitions the server to the started state and processes any pending connections.
+	///
+	/// This method performs a one-time transition from the `.pending` to the `.started` state.
+	/// Calling it on a server that is already started or has been invalidated will have no effect.
     public func start() {
         self.listenerQueue.sync {
-            self.started = true
-            for connection in self.pendingConnections {
-                self.startClientConnection(connection)
-            }
-            self.pendingConnections.removeAll()
+			if case let .pending(connections) = self.state {
+				self.state = .started
+				for connection in connections {
+					self.startClientConnection(connection)
+				}
+			}
         }
     }
 }
@@ -125,18 +192,31 @@ extension XPCMachServer {
         }
     }
 
-	/// Finds a cached server by its Mach service name, invalidates it and removes it from cache.
+	/// Asynchronously invalidates a cached server by its Mach service name and removes it from the cache.
 	///
-	/// This provides a thread-safe way to shut down a specific, shared server instance
-	/// from anywhere in the application. If no server with the given name is found
-	/// in the cache, this method does nothing.
+	/// This provides a thread-safe way to shut down a specific, shared server instance.
+	/// The completion handler is called after the server has been removed from the cache and its
+	/// asynchronous invalidation process has been initiated.
 	///
-	/// - Parameter machServiceName: The name of the Mach service server to invalidate.
-	internal static func invalidateServer(named machServiceName: String) {
-		serialQueue.sync {
+	/// If no server with the given name is found, the completion handler is called immediately.
+	///
+	/// - Parameters:
+	///   - machServiceName: The name of the Mach service server to invalidate.
+	///   - queue: The dispatch queue on which to execute the completion handler.
+	///   - completion: The closure to be called once the operation is complete.
+	internal static func invalidateServer(
+		named machServiceName: String,
+		on queue: DispatchQueue,
+		completion: @escaping () -> Void
+	) {
+		serialQueue.async {
 			if let cachedServer = machServerCache[machServiceName] {
-				machServerCache[machServiceName] = nil
-				cachedServer.invalidate()
+				cachedServer.invalidate(on: serialQueue) {
+					machServerCache[machServiceName] = nil
+					queue.async { completion() }
+				}
+			} else {
+				queue.async { completion() }
 			}
 		}
 	}

--- a/Sources/SecureXPC/Server/XPCServer.swift
+++ b/Sources/SecureXPC/Server/XPCServer.swift
@@ -104,6 +104,23 @@ import Foundation
 /// handling a request from a client, there is a possibility that a subsequent request will be received by the server process before termination has completed meaning
 /// it will nearly instantly fail with an ``XPCError/connectionInterrupted`` error. Allow launchd to automatically manage the lifecycle of your service.
 ///
+/// ### Invalidating a Server
+/// While it's recommended to allow `launchd` to manage the lifecycle of your service, a
+/// server can be manually invalidated if needed. This is particularly useful for XPC Mach
+/// services that are managed as shared, cached instances.
+///
+/// Invalidating a server will gracefully terminate all of its active client connections
+/// and remove it from the internal cache, allowing it to be deallocated.
+///
+/// ```swift
+/// let serviceName = "com.example.helper.service"
+/// // ... at some point, the server is retrieved and started
+/// try XPCServer.forMachService(named: serviceName)
+///
+/// // Later, when you need to shut down the service:
+/// XPCServer.invalidateMachService(named: serviceName)
+/// ```
+///
 /// ## Topics
 /// ### Retrieving a Server
 /// - ``forThisXPCService()``
@@ -160,7 +177,16 @@ public class XPCServer {
         self.clientRequirement = clientRequirement
         self.registerPackageInternalRoutes()
     }
-    
+
+	// MARK: Lifecycle
+
+	/// Invalidates the server, stops it from accepting new connections, and disconnects all clients.
+	///
+	/// This method is for internal use within the library.
+	internal func invalidate() {
+		fatalError("Abstract Method: This must be overridden by a subclass.")
+	}
+
     // MARK: Route registration
     
     private var routes = [XPCRoute : XPCHandler]()
@@ -636,6 +662,23 @@ extension XPCServer {
     ) throws -> XPCServer & XPCNonBlockingServer {
         try XPCMachServer.getXPCMachServer(criteria: criteria)
     }
+}
+
+// MARK: Server Lifecycle Management
+
+extension XPCServer {
+	/// Finds and invalidates a cached XPC Mach service server by its name.
+	///
+	/// This is the designated public method for shutting down a shared Mach service.
+	/// It ensures the server is safely removed from the cache and that its underlying
+	/// listener connection is terminated.
+	///
+	/// If no server with the given name is currently active in the cache, this method does nothing.
+	///
+	/// - Parameter machServiceName: The name of the Mach service to invalidate.
+	public static func invalidateMachService(named machServiceName: String) {
+		XPCMachServer.invalidateServer(named: machServiceName)
+	}
 }
 
 // MARK: handler function wrappers

--- a/Sources/SecureXPC/Server/XPCServer.swift
+++ b/Sources/SecureXPC/Server/XPCServer.swift
@@ -109,16 +109,20 @@ import Foundation
 /// server can be manually invalidated if needed. This is particularly useful for XPC Mach
 /// services that are managed as shared, cached instances.
 ///
-/// Invalidating a server will gracefully terminate all of its active client connections
-/// and remove it from the internal cache, allowing it to be deallocated.
+/// Invalidating a server is an asynchronous operation. It gracefully terminates all
+/// active client connections and removes the server from the internal cache, allowing it
+/// to be deallocated. You can optionally provide a completion handler to be notified
+
+/// when the process is finished.
 ///
 /// ```swift
 /// let serviceName = "com.example.helper.service"
 /// // ... at some point, the server is retrieved and started
-/// try XPCServer.forMachService(named: serviceName)
 ///
-/// // Later, when you need to shut down the service:
-/// XPCServer.invalidateMachService(named: serviceName)
+/// // Later, when you need to shut down the service and wait for it to complete:
+/// XPCServer.invalidateMachService(named: serviceName, on: .main) {
+///     print("Server has been fully invalidated.")
+/// }
 /// ```
 ///
 /// ## Topics
@@ -180,10 +184,21 @@ public class XPCServer {
 
 	// MARK: Lifecycle
 
-	/// Invalidates the server, stops it from accepting new connections, and disconnects all clients.
+	/// Asynchronously invalidates the server, stopping new connections and disconnecting all clients.
 	///
-	/// This method is for internal use within the library.
-	internal func invalidate() {
+	/// This method initiates a graceful shutdown. The completion handler is called only
+	/// after the system confirms the listener has been fully invalidated.
+	///
+	/// If this method is called while an invalidation is already in progress, the new
+	/// completion handler is ignored.
+	///
+	/// - Parameters:
+	///   - queue: The dispatch queue on which to execute the completion handler.
+	///   - completion: The closure to be called when invalidation is complete.
+	internal func invalidate(
+		on queue: DispatchQueue,
+		completion: @escaping () -> Void
+	) {
 		fatalError("Abstract Method: This must be overridden by a subclass.")
 	}
 
@@ -667,17 +682,24 @@ extension XPCServer {
 // MARK: Server Lifecycle Management
 
 extension XPCServer {
-	/// Finds and invalidates a cached XPC Mach service server by its name.
+	/// Asynchronously invalidates a cached XPC Mach service server by its name.
 	///
 	/// This is the designated public method for shutting down a shared Mach service.
 	/// It ensures the server is safely removed from the cache and that its underlying
 	/// listener connection is terminated.
 	///
-	/// If no server with the given name is currently active in the cache, this method does nothing.
+	/// If no server is found, the completion handler is called immediately.
 	///
-	/// - Parameter machServiceName: The name of the Mach service to invalidate.
-	public static func invalidateMachService(named machServiceName: String) {
-		XPCMachServer.invalidateServer(named: machServiceName)
+	/// - Parameters:
+	///   - machServiceName: The name of the Mach service to invalidate.
+	///   - queue: An optional dispatch queue on which to execute the completion handler.
+	///   - completion: An optional closure to be called once the operation is complete.
+	public static func invalidateMachService(
+		named machServiceName: String,
+		on queue: DispatchQueue = .global(),
+		completion: @escaping () -> Void = { }
+	) {
+		XPCMachServer.invalidateServer(named: machServiceName, on: queue, completion: completion)
 	}
 }
 


### PR DESCRIPTION
## Description

The original `XPCServer` was intentionally designed without a method to stop it, relying on `launchd` to manage its lifecycle. This makes it difficult to shut down a server gracefully or release its resources for manual cleanup.

This PR introduces a new public API to invalidate a running XPC Mach service, allowing for proper lifecycle management and preventing memory leaks caused by the server's persistent strong references.

## Changes Made

* Added a `public static func invalidateMachService(named:)` method to the `XPCServer` API for gracefully shutting down a specific Mach service.
* Implemented the underlying thread-safe logic in `XPCMachServer` to manage the server cache and cancel the listener connection, breaking the retain chain to prevent memory leaks.
* Updated the header documentation with a new `### Invalidating a Server` section to explain the new feature.