### PR TITLE
Ensure correct error propagation for sequential replies

### DIFF
--- a/Sources/SecureXPC/Server/XPCServer.swift
+++ b/Sources/SecureXPC/Server/XPCServer.swift
@@ -448,13 +448,33 @@ public class XPCServer {
             // concurrent. (Although if an API user sets the target queue to be serial that's supported too.)
             self.handlerQueue.async {
                 XPCServer.ClientIdentity.setForCurrentThread(connection: connection, message: message) {
-                    var reply = handler.shouldCreateReply ? xpc_dictionary_create_reply(message) : nil
+					var reply = handler.shouldCreateReply ? xpc_dictionary_create_reply(message) : nil
                     do {
                         try handler.handle(request: request, server: self, connection: connection, reply: &reply)
                         try self.maybeSendReply(&reply, request: request, connection: connection)
                     } catch {
-                        var reply = handler.shouldCreateReply ? reply : xpc_dictionary_create_reply(message)
-                        self.handleError(error, request: request, connection: connection, reply: &reply)
+						guard !handler.shouldCreateReply else {
+							self.handleError(error, request: request, connection: connection, reply: &reply)
+							return
+						}
+
+						let error = XPCError.asXPCError(error: error)
+						self.errorHandler.handle(error, connection.token)
+
+						// If it's possible to reply, then send the error back to the client
+						do {
+							var response = xpc_dictionary_create(nil, nil, 0)
+							try Response.encodeRequestID(request.requestID, intoReply: &response)
+							try Response.encodeError(error, intoReply: &response)
+							xpc_connection_send_message(connection, response)
+
+							// End Transaction
+							if let reply = xpc_dictionary_create_reply(message) {
+								xpc_connection_send_message(connection, reply)
+							}
+						} catch {
+							// If these actions fail, then there's no way to proceed
+						}
                     }
                 }
             }
@@ -478,8 +498,28 @@ public class XPCServer {
                         try await handler.handle(request: request, server: self, connection: connection, reply: &reply)
                         try self.maybeSendReply(&reply, request: request, connection: connection)
                     } catch {
-                        var reply = handler.shouldCreateReply ? reply : xpc_dictionary_create_reply(message)
-                        self.handleError(error, request: request, connection: connection, reply: &reply)
+						guard !handler.shouldCreateReply else {
+							self.handleError(error, request: request, connection: connection, reply: &reply)
+							return
+						}
+
+						let error = XPCError.asXPCError(error: error)
+						self.errorHandler.handle(error, connection.token)
+
+						// If it's possible to reply, then send the error back to the client
+						do {
+							var response = xpc_dictionary_create(nil, nil, 0)
+							try Response.encodeRequestID(request.requestID, intoReply: &response)
+							try Response.encodeError(error, intoReply: &response)
+							xpc_connection_send_message(connection, response)
+
+							// End Transaction
+							if let reply = xpc_dictionary_create_reply(message) {
+								xpc_connection_send_message(connection, reply)
+							}
+						} catch {
+							// If these actions fail, then there's no way to proceed
+						}
                     }
                 }
             }
@@ -850,8 +890,8 @@ fileprivate struct ConstrainedXPCHandlerWithMessageWithSequentialReplySync<M: De
 
     func handle(request: Request, server: XPCServer, connection: xpc_connection_t, reply: inout xpc_object_t?) throws {
         try checkRequest(request, reply: &reply, messageType: M.self, replyType: nil, sequentialReplyType: S.self)
-        let sequenceProvider = SequentialResultProvider<S>(request: request, server: server, connection: connection)
         let decodedMessage = try request.decodePayload(asType: M.self)
+		let sequenceProvider = SequentialResultProvider<S>(request: request, server: server, connection: connection)
         self.handler(connection.token, decodedMessage, sequenceProvider)
     }
 }

--- a/Sources/SecureXPC/Server/XPCServer.swift
+++ b/Sources/SecureXPC/Server/XPCServer.swift
@@ -453,27 +453,10 @@ public class XPCServer {
                         try handler.handle(request: request, server: self, connection: connection, reply: &reply)
                         try self.maybeSendReply(&reply, request: request, connection: connection)
                     } catch {
-						guard !handler.shouldCreateReply else {
+						if handler.shouldCreateReply {
 							self.handleError(error, request: request, connection: connection, reply: &reply)
-							return
-						}
-
-						let error = XPCError.asXPCError(error: error)
-						self.errorHandler.handle(error, connection.token)
-
-						// If it's possible to reply, then send the error back to the client
-						do {
-							var response = xpc_dictionary_create(nil, nil, 0)
-							try Response.encodeRequestID(request.requestID, intoReply: &response)
-							try Response.encodeError(error, intoReply: &response)
-							xpc_connection_send_message(connection, response)
-
-							// End Transaction
-							if let reply = xpc_dictionary_create_reply(message) {
-								xpc_connection_send_message(connection, reply)
-							}
-						} catch {
-							// If these actions fail, then there's no way to proceed
+						} else {
+							self.handleError(error, request: request, connection: connection)
 						}
                     }
                 }
@@ -498,27 +481,10 @@ public class XPCServer {
                         try await handler.handle(request: request, server: self, connection: connection, reply: &reply)
                         try self.maybeSendReply(&reply, request: request, connection: connection)
                     } catch {
-						guard !handler.shouldCreateReply else {
+						if handler.shouldCreateReply {
 							self.handleError(error, request: request, connection: connection, reply: &reply)
-							return
-						}
-
-						let error = XPCError.asXPCError(error: error)
-						self.errorHandler.handle(error, connection.token)
-
-						// If it's possible to reply, then send the error back to the client
-						do {
-							var response = xpc_dictionary_create(nil, nil, 0)
-							try Response.encodeRequestID(request.requestID, intoReply: &response)
-							try Response.encodeError(error, intoReply: &response)
-							xpc_connection_send_message(connection, response)
-
-							// End Transaction
-							if let reply = xpc_dictionary_create_reply(message) {
-								xpc_connection_send_message(connection, reply)
-							}
-						} catch {
-							// If these actions fail, then there's no way to proceed
+						} else {
+							self.handleError(error, request: request, connection: connection)
 						}
                     }
                 }
@@ -570,7 +536,31 @@ public class XPCServer {
             }
         }
     }
-    
+
+	private func handleError(
+		_ error: Error,
+		request: Request,
+		connection: xpc_connection_t
+	) {
+		let error = XPCError.asXPCError(error: error)
+		self.errorHandler.handle(error, connection.token)
+
+		// If it's possible to reply, then send the error back to the client
+		do {
+			var response = xpc_dictionary_create(nil, nil, 0)
+			try Response.encodeRequestID(request.requestID, intoReply: &response)
+			try Response.encodeError(error, intoReply: &response)
+			xpc_connection_send_message(connection, response)
+
+			// End Transaction
+			if let reply = xpc_dictionary_create_reply(request.dictionary) {
+				xpc_connection_send_message(connection, reply)
+			}
+		} catch {
+			// If these actions fail, then there's no way to proceed
+		}
+	}
+
     /// Tries to send a reply if the `reply` and `request` objects aren't nil.
     private func maybeSendReply(_ reply: inout xpc_object_t?, request: Request?, connection: xpc_connection_t) throws {
         if var reply = reply, let request = request {


### PR DESCRIPTION
### Problem

There were two related issues when a decoding error occurred for a route using `SequentialResultProvider`:

1.  If the message failed to decode, the `SequentialResultProvider` was already initialized. Its `deinit` would then send a `finished` status, incorrectly masking the decoding error.
2.  The server's global `catch` block would close the XPC transaction without first sending a properly formatted error message that the client-side provider could interpret.

This resulted in the client receiving a **`finished`** status instead of an appropriate **error**.

---

### Solution

This PR addresses the issue with a two-part fix:

1.  **Delayed Initialization**: The `SequentialResultProvider` is now created only **after** the incoming message has been successfully decoded. This ensures that a decoding failure is thrown and caught before the provider is ever instantiated, preventing its `deinit` from sending a misleading `finished` status.

2.  **Corrected Error Handling**: The server's error handling logic for sequential replies has been updated. It now explicitly sends a new XPC message containing the error details first, and only then closes the underlying XPC transaction.

These changes guarantee that decoding errors are correctly propagated to the client as an error state, not as a successful completion.