### PR TITLE
add missing single value encoder support for XPCRawEncodable

### DIFF
--- a/Sources/SecureXPC/XPC Coders/XPCDecoder/XPCKeyedDecodingContainer.swift
+++ b/Sources/SecureXPC/XPC Coders/XPCDecoder/XPCKeyedDecodingContainer.swift
@@ -139,7 +139,7 @@ internal class XPCKeyedDecodingContainer<K: CodingKey>: KeyedDecodingContainerPr
             let value = try value(forKey: key)
             guard let decodedType = castedType.init(xpcRawValue: value) as? T else {
                 let context = DecodingError.Context(codingPath: codingPath,
-                                                    debugDescription: "Unable to decode array",
+                                                    debugDescription: "Unable to decode \(type))",
                                                     underlyingError: nil)
                 throw DecodingError.dataCorrupted(context)
             }

--- a/Sources/SecureXPC/XPC Coders/XPCDecoder/XPCSingleValueDecodingContainer.swift
+++ b/Sources/SecureXPC/XPC Coders/XPCDecoder/XPCSingleValueDecodingContainer.swift
@@ -98,9 +98,20 @@ internal class XPCSingleValueDecodingContainer: SingleValueDecodingContainer {
 	}
 
 	func decode<T>(_ type: T.Type) throws -> T where T : Decodable {
-		return try type.init(from: XPCDecoderImpl(value: self.value,
-                                                  codingPath: self.codingPath,
-                                                  userInfo: self.userInfo))
+        if let castedType = type as? XPCRawDecodable.Type {
+            let value = self.value
+            guard let decodedType = castedType.init(xpcRawValue: value) as? T else {
+                let context = DecodingError.Context(codingPath: codingPath,
+                                                    debugDescription: "Unable to decode \(type)",
+                                                    underlyingError: nil)
+                throw DecodingError.dataCorrupted(context)
+            }
+            return decodedType
+        } else {
+            return try type.init(from: XPCDecoderImpl(value: self.value,
+                                                      codingPath: self.codingPath,
+                                                      userInfo: self.userInfo))
+        }
 	}
     
     // MARK: XPC specific decoding

--- a/Sources/SecureXPC/XPC Coders/XPCDecoder/XPCUnkeyedDecodingContainer.swift
+++ b/Sources/SecureXPC/XPC Coders/XPCDecoder/XPCUnkeyedDecodingContainer.swift
@@ -169,7 +169,7 @@ private class XPCArrayBackedUnkeyedDecodingContainer: UnkeyedDecodingContainer {
             let xpcObject = try nextElement(type)
             guard let nextElement = castedType.init(xpcRawValue: xpcObject) else {
                 let context = DecodingError.Context(codingPath: codingPath,
-                                                    debugDescription: "Unable to decode array",
+                                                    debugDescription: "Unable to \(type)",
                                                     underlyingError: nil)
                 throw DecodingError.dataCorrupted(context)
             }

--- a/Sources/SecureXPC/XPC Coders/XPCEncoder/XPCKeyedEncodingContainer.swift
+++ b/Sources/SecureXPC/XPC Coders/XPCEncoder/XPCKeyedEncodingContainer.swift
@@ -113,21 +113,10 @@ internal class XPCKeyedEncodingContainer<K>: KeyedEncodingContainerProtocol, XPC
 		self.setValue(xpc_uint64_create(value), forKey: key)
 	}
 
-    func encode(_ value: XPCRawEncodable, forKey key: K) throws {
-        guard let encodedValue = value.xpcRawValue() else {
-            let debugDescription = "Unable to encode \(self.self) to XPC data representation"
-            let context = EncodingError.Context(codingPath: codingPath,
-                                                debugDescription: debugDescription,
-                                                underlyingError: nil)
-            throw EncodingError.invalidValue(self, context)
-        }
-        self.setValue(encodedValue, forKey: key)
-    }
-
 	func encode<T>(_ value: T, forKey key: K) throws where T : Encodable {
         if let castedType = value as? XPCRawEncodable {
             guard let encodedValue = castedType.xpcRawValue() else {
-                let debugDescription = "Unable to encode \(self.self) to XPC data representation"
+                let debugDescription = "Unable to encode \(value.self)"
                 let context = EncodingError.Context(codingPath: codingPath,
                                                     debugDescription: debugDescription,
                                                     underlyingError: nil)

--- a/Sources/SecureXPC/XPC Coders/XPCEncoder/XPCSingleValueEncodingContainer.swift
+++ b/Sources/SecureXPC/XPC Coders/XPCEncoder/XPCSingleValueEncodingContainer.swift
@@ -97,7 +97,7 @@ internal class XPCSingleValueEncodingContainer: SingleValueEncodingContainer, XP
 	func encode<T: Encodable>(_ value: T) throws {
         if let castedValue = value as? XPCRawEncodable {
             guard let encodedValue = castedValue.xpcRawValue() else {
-                let debugDescription = "Unable to encode \(self.self) to XPC data representation"
+                let debugDescription = "Unable to encode \(value.self)"
                 let context = EncodingError.Context(codingPath: codingPath,
                                                     debugDescription: debugDescription,
                                                     underlyingError: nil)

--- a/Sources/SecureXPC/XPC Coders/XPCEncoder/XPCUnkeyedEncodingContainer.swift
+++ b/Sources/SecureXPC/XPC Coders/XPCEncoder/XPCUnkeyedEncodingContainer.swift
@@ -175,7 +175,7 @@ internal class XPCUnkeyedEncodingContainer : UnkeyedEncodingContainer, XPCContai
         if let castedValue = value as? XPCRawEncodable {
             self.attemptDataBackedAppend(castedValue)
             guard let encodedValue = castedValue.xpcRawValue() else {
-                let debugDescription = "Unable to encode \(self.self) to XPC data representation"
+                let debugDescription = "Unable to encode \(value.self)"
                 let context = EncodingError.Context(codingPath: codingPath,
                                                     debugDescription: debugDescription,
                                                     underlyingError: nil)


### PR DESCRIPTION
This PR addresses minor issues:
* add missing support of `XPCRawDecodable` to single value decoder
* fix error messages 